### PR TITLE
Fixed Typescript version

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -30,6 +30,6 @@
     "tsup": "^8.0.2"
   },
   "peerDependencies": {
-    "typescript": "5.3.0"
+    "typescript": "^5.4.4"
   }
 }


### PR DESCRIPTION
Hello again!

Getting an error about invalid Typescript version whenever I install token-icons.

```shell
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: @token-icons/core@2.1.0
npm WARN Found: typescript@undefined
npm WARN node_modules/typescript
npm WARN
npm WARN Could not resolve dependency:
npm WARN peer typescript@"5.3.0" from @token-icons/core@2.1.0
npm WARN node_modules/@token-icons/core
npm WARN   dev @token-icons/core@"^2.1.0" from the root project
npm ERR! code ETARGET
npm ERR! notarget No matching version found for typescript@5.3.0.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
```

I updated Typescript's version to [5.4.4](https://www.npmjs.com/package/typescript/v/5.4.4) to hopefully resolve the issue.

Thanks!