### PR TITLE
fix typescript versions for peerDependencies

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @token-icons/core
 
+## 2.3.2
+
+### Patch Changes
+
+- lower typescript version
+
 ## 2.3.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,6 @@
     "svgo": "^3.2.0"
   },
   "peerDependencies": {
-    "typescript": "5.3.0"
+    "typescript": "^5.0.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
     "svg crypto icons",
     "coin icons"
   ],
-  "version": "2.3.1",
+  "version": "2.3.2",
   "private": false,
   "license": "MIT",
   "type": "module",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @token-icons/react
 
+## 2.3.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @token-icons/core@2.3.2
+
 ## 2.3.1
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,7 +11,7 @@
     "crypto logos",
     "coin icons"
   ],
-  "version": "2.3.1",
+  "version": "2.3.2",
   "private": false,
   "license": "MIT",
   "main": "./dist/index.js",
@@ -38,7 +38,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,md,mdx,json}\" --log-level error"
   },
   "dependencies": {
-    "@token-icons/core": "2.3.1"
+    "@token-icons/core": "2.3.2"
   },
   "devDependencies": {
     "@svgr/core": "^8.1.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -30,6 +30,6 @@
     "tsup": "^8.0.2"
   },
   "peerDependencies": {
-    "typescript": "^5.4.4"
+    "typescript": "^5.0.0"
   }
 }


### PR DESCRIPTION
Hello! Thank you for your work!

This PR proposes changing the required TypeScript version from "^5.3.5" and "^5.4.4" to "^5.0.0". Currently, versions "^5.3.5" "^5.4.4" are causing dependency issues for users of our library as this version does not exist in the npm repository.

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: trix@0.0.1
npm ERR! Found: typescript@5.4.5
npm ERR! node_modules/typescript
npm ERR!   dev typescript@"^5.3.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer typescript@"5.3.0" from @token-icons/core@2.3.1
npm ERR! node_modules/@token-icons/core
npm ERR!   @token-icons/core@"^2.3.1" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```


Lowering the TypeScript version to "^5.0.0" will address these dependency issues and ensure broader compatibility with various versions of TypeScript.

I am ready to discuss any questions or concerns regarding this proposed change.