### PR TITLE
fix(ci): remove commitMode github-api due to symlink incompatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,5 @@ jobs:
           version: bun run version
           publish: bun run release
           createGithubReleases: true
-          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Remove `commitMode: github-api` from the release workflow
- GitHub API doesn't support symlinks, and `CLAUDE.md` is a symlink to `AGENTS.md`
- Using the default git-based commit mode instead

## Test plan
- [ ] Merge this PR and verify the release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)