### PR TITLE
fix(common,core): remove typescript peer dep, add types for deep SVG imports

### DIFF
--- a/.changeset/remove-typescript-peer-dep.md
+++ b/.changeset/remove-typescript-peer-dep.md
@@ -1,0 +1,6 @@
+---
+'@web3icons/common': patch
+'@web3icons/core': patch
+---
+
+remove `typescript` from peerDependencies — it blocked installs for TypeScript 6 users and force-installed TypeScript for JS-only consumers (fixes #195)

--- a/.changeset/svg-deep-import-types.md
+++ b/.changeset/svg-deep-import-types.md
@@ -1,0 +1,5 @@
+---
+'@web3icons/core': patch
+---
+
+emit `.d.ts` declarations for deep SVG imports (e.g. `@web3icons/core/svgs/tokens/branded/BTC.svg.js`), add missing `./svgs/exchanges/*` to package exports, and point the `types` field at the actual `dist/index.d.ts` (fixes #194)

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -62,8 +62,5 @@
   },
   "devDependencies": {
     "bun-types": "latest"
-  },
-  "peerDependencies": {
-    "typescript": "^5.0.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "dist/**/*"
   ],
@@ -29,7 +29,8 @@
     },
     "./svgs/tokens/*": "./dist/svgs/tokens/*",
     "./svgs/networks/*": "./dist/svgs/networks/*",
-    "./svgs/wallets/*": "./dist/svgs/wallets/*"
+    "./svgs/wallets/*": "./dist/svgs/wallets/*",
+    "./svgs/exchanges/*": "./dist/svgs/exchanges/*"
   },
   "sideEffects": false,
   "repository": {
@@ -41,10 +42,11 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bun run pre-build && rollup -c && bun format",
+    "build": "bun run clean && bun run pre-build && rollup -c && bun format",
     "pre-build": "cd ../../scripts/build-scripts/core && bun core.pre-build.ts",
     "lint": "eslint ./src --ext .ts",
-    "format": "prettier --write \"**/*.{ts,js,md,json}\" --log-level error"
+    "format": "prettier --write \"**/*.{ts,js,md,json}\" --log-level error",
+    "clean": "rm -rf dist"
   },
   "dependencies": {
     "@web3icons/common": "0.11.47"
@@ -54,8 +56,5 @@
     "cheerio": "^1.0.0-rc.12",
     "svgo": "^3.2.0",
     "rollup-plugin-string": "^3.0.0"
-  },
-  "peerDependencies": {
-    "typescript": "^5.0.0"
   }
 }

--- a/packages/core/rollup.config.mjs
+++ b/packages/core/rollup.config.mjs
@@ -6,6 +6,24 @@ const svgPlugin = string({
   include: '**/*.svg',
 });
 
+// Emit a declaration file next to every .svg.js chunk so TypeScript
+// consumers can deep-import raw SVG strings without implicit-any errors,
+// e.g. `import btc from '@web3icons/core/svgs/tokens/branded/BTC.svg.js'`
+const svgDtsPlugin = {
+  name: 'svg-dts',
+  generateBundle(_, bundle) {
+    for (const fileName of Object.keys(bundle)) {
+      if (fileName.endsWith('.svg.js')) {
+        this.emitFile({
+          type: 'asset',
+          fileName: fileName.replace(/\.js$/, '.d.ts'),
+          source: 'declare const svg: string\nexport default svg\n',
+        });
+      }
+    }
+  },
+};
+
 const config = createESMConfig({
   input: 'src/index.ts',
   outputDir: 'dist',
@@ -14,6 +32,6 @@ const config = createESMConfig({
 });
 
 // Add SVG loader plugin
-config.plugins.push(svgPlugin);
+config.plugins.push(svgPlugin, svgDtsPlugin);
 
 export default config;


### PR DESCRIPTION
Fixes #195
Fixes #194

## What

Two consumer-facing packaging fixes for `@web3icons/common` and `@web3icons/core`, plus small hygiene.

### #195 — `typescript` in peerDependencies blocked installs
`common` and `core` declared `"peerDependencies": { "typescript": "^5.0.0" }`. TypeScript is a build tool, not a shared runtime — this caused:
- `ERESOLVE` conflicts for users on TypeScript 6 (reproduced against the published packages)
- npm 7+ force-installing TypeScript into JS-only projects (the reporter's Babel + Vite case)

**Fix:** removed the peer dependency from both packages (`react` keeps typescript only in devDependencies, which is invisible to consumers).

### #194 — no type declarations for deep SVG imports
`import btc from '@web3icons/core/svgs/tokens/branded/BTC.svg.js'` resolved at runtime but produced TS7016 implicit-`any` because the rollup `preserveModules` output has no declarations for `.svg`-derived chunks.

**Fix:** a small rollup plugin in `packages/core/rollup.config.mjs` emits a sibling `.d.ts` (`declare const svg: string; export default svg`) for every `.svg.js` chunk — 5949/5949 coverage verified. Along the way:
- added the missing `./svgs/exchanges/*` subpath export (exchange deep imports were not exported at all)
- fixed the `types` field to point at `dist/index.d.ts` (`dist/types/index.d.ts` never existed)
- added a `clean` step to core's build so stale dist files can't linger (matches `common`)

## Verification

Tested against an `npm pack` tarball installed into a fresh consumer project:
- **Runtime:** main entry + deep token/exchange imports return SVG strings ✅
- **Types:** `tsc --strict` passes under `moduleResolution: bundler` and `node16` (+`skipLibCheck`, the near-universal default) ✅ — the published package reproduces issue #194's error verbatim under the same config
- **Installs:** `npm install typescript@latest` alongside — no peer conflicts (published packages emit `ERESOLVE` warnings) ✅
- **No files disappear:** published tarball vs fresh build file sets are identical (5949 = 5949) ✅

Pre-existing issues intentionally not touched: `dist/svg-module.d.ts` has extensionless `.svg` imports that fail lib-check under `node16` without `skipLibCheck`, and legacy `node10` resolution can't resolve the deep subpaths (it ignores `exports` — was also true at runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)